### PR TITLE
endpoint statistics added as getrequest according to Discord, swagger…

### DIFF
--- a/js_serverless/src/app/routes/matchRoutes.js
+++ b/js_serverless/src/app/routes/matchRoutes.js
@@ -4,6 +4,7 @@ import {
   submitMatchScore,
   getAllMatches,
   findMatchesByTeam,
+  getMatchStatistics,
 } from "../../services/matchService.js";
 import validateMatch from "../../utils/validateMatch.js";
 import { verifyToken } from "../../utils/jwt.js";
@@ -153,6 +154,35 @@ router.get("/search", auth(), async (req, res) => {
 
     const matches = await findMatchesByTeam(team);
     res.json(matches);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * @swagger
+ * /api/v1/match/statistics:
+ *   get:
+ *     tags: [Match]
+ *     summary: Get aggregated match score statistics
+ *     description: Returns average, minimum and maximum scores for home and away teams.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Aggregated match statistics
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MatchStatistics'
+ *       401:
+ *         description: Unauthorized
+ */
+router.get("/statistics", auth(), async (_req, res) => {
+  try {
+    const stats = await getMatchStatistics();
+    res.json(stats);
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: err.message });

--- a/js_serverless/src/docs/components.js
+++ b/js_serverless/src/docs/components.js
@@ -50,6 +50,24 @@
  *           format: date
  *         winningTeam:
  *           type: string
+ * 
+ *     MatchStatistics:
+ *       type: object
+ *       properties:
+ *         avg_home_score:
+ *           type: number
+ *           format: float
+ *         avg_away_score:
+ *           type: number
+ *           format: float
+ *         min_home_score:
+ *           type: integer
+ *         max_home_score:
+ *           type: integer
+ *         min_away_score:
+ *           type: integer
+ *         max_away_score:
+ *           type: integer
  *
  *     RegisterRequest:
  *       type: object

--- a/js_serverless/src/services/matchService.js
+++ b/js_serverless/src/services/matchService.js
@@ -71,3 +71,21 @@ export async function findMatchesByTeam(team) {
   );
   return rows;
 }
+
+// Get match score statistics
+export async function getMatchStatistics() {
+  const { rows } = await pool.query(`
+    SELECT
+      AVG(home_team_score) AS avg_home_score,
+      AVG(away_team_score) AS avg_away_score,
+
+      MIN(home_team_score) AS min_home_score,
+      MAX(home_team_score) AS max_home_score,
+
+      MIN(away_team_score) AS min_away_score,
+      MAX(away_team_score) AS max_away_score
+    FROM matches
+  `);
+
+  return rows[0];
+}


### PR DESCRIPTION
… documentation added

<!--- Provide a general summary of your changes in the Title above -->

## Description

Get request for endpoint statistics with Swagger documentation.
Returning result from:
SELECT
    AVG(home_team_score) AS avg_home_score,
    AVG(away_team_score) AS avg_away_score,

    MIN(home_team_score) AS min_home_score,
    MAX(home_team_score) AS max_home_score,

    MIN(away_team_score) AS min_away_score,
    MAX(away_team_score) AS max_away_score
FROM matches;
as wanted in Discord.

## Related Issue

Team statistics

## Checklist

<!-- Must have space inside [] to show as checkbox -->

Add x inside [ ] to check if applicable, else leave unchecked:

Required

- [x] Code runs locally

Optional

- [ ] Tests added or updated
- [ ] Configurations added or updated
- [x] Documentation updated
